### PR TITLE
/vanish support for join and leave messages [WIP]

### DIFF
--- a/src/main/kotlin/xyz/jpenilla/announcerplus/compatibility/EssentialsHook.kt
+++ b/src/main/kotlin/xyz/jpenilla/announcerplus/compatibility/EssentialsHook.kt
@@ -35,10 +35,6 @@ class EssentialsHook {
     return user(player).isAfk
   }
 
-  fun isVanished(player: Player): Boolean {
-    return user(player).isVanished
-  }
-
   fun user(player: Player): IUser {
     return essentials.getUser(player)
   }

--- a/src/main/kotlin/xyz/jpenilla/announcerplus/config/ConfigManager.kt
+++ b/src/main/kotlin/xyz/jpenilla/announcerplus/config/ConfigManager.kt
@@ -293,6 +293,21 @@ class ConfigManager(
     return msg
   }
 
+  fun parse(commandSender: String, message: String): String {
+    var msg = message
+    mainConfig.customPlaceholders.forEach { (token, replacement) ->
+      msg = msg.replace("{$token}", replacement)
+    }
+    msg = legacyChecker.check(msg)
+
+    if (msg.startsWith("<center>")) {
+      msg = msg.replaceFirst("<center>", "")
+      val spaces = ChatCentering.spacePrefix(miniMessage(msg))
+      return spaces + msg
+    }
+    return msg
+  }
+
   fun parse(player: CommandSender?, messages: List<String>): List<String> =
     messages.map { parse(player, it) }
 }


### PR DESCRIPTION
Using the main branch of AnnouncerPlus, I was getting duplicate join and leave messages when using /vanish. So I made an attempt to fix the issue. The fix resulted in a new bug where the username is blank during the leave message. I don't really understand Kotlin well enough to figure out what is wrong with it. If someone could pick up this PR and finish it, I would be very appreciative.

There was an attempt (TM).